### PR TITLE
gui/svglistitemdelegate: Fix incomplete type error with Qt 5.15.1

### DIFF
--- a/gui/svglistitemdelegate.cpp
+++ b/gui/svglistitemdelegate.cpp
@@ -19,6 +19,7 @@
 #include "svglistitemdelegate.h"
 
 #include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QtGui/QPixmapCache>
 #include <QtSvg/QSvgRenderer>
 


### PR DESCRIPTION
Fixes this compiler error:

    svg2svgt/gui/svglistitemdelegate.cpp: In member function ‘virtual void SvgListItemDelegate::paint(QPainter*, const QStyleOptionViewItem&, const QModelIndex&) const’:
    svg2svgt/gui/svglistitemdelegate.cpp:54:22: error: aggregate ‘QPainterPath roundedRect’ has incomplete type and cannot be defined
       54 |         QPainterPath roundedRect;
          |                      ^~~~~~~~~~~